### PR TITLE
initial 0.1.6

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,6 +35,11 @@ about:
   license_family: Apache
   license_file: LICENSE
   summary: This is a module for the AWS SDK for C.
+  description: |
+    C99 library implementing AWS SDK specific utilities. 
+    Includes utilities for ARN parsing, reading AWS profiles, etc...
+  doc_url: https://github.com/awslabs/aws-c-sdkutils
+  dev_url: https://github.com/awslabs/aws-c-sdkutils
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "aws-c-sdkutils" %}
-{% set version = "0.1.14" %}
+{% set version = "0.1.6" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/awslabs/{{ name }}/archive/v{{ version }}.tar.gz
-  sha256: 5acb6dd916511a3dff14faea43385d117d755f4ad4a9c52314cc74e427398f37
+  sha256: 8a2951344b2fb541eab1e9ca17c18a7fcbfd2aaff4cdd31d362d1fad96111b91
 
 build:
   number: 0
@@ -18,9 +18,9 @@ requirements:
   build:
     - cmake !=3.19.0,!=3.19.1
     - {{ compiler('c') }}
-    - ninja
+    - ninja-base
   host:
-    - aws-c-common
+    - aws-c-common 0.8.5
 
 test:
   commands:


### PR DESCRIPTION
aws-c-sdkutils 0.1.6

Destination channel: defaults

Links
[{ticket_number}](https://anaconda.atlassian.net/browse/PKG-3948)
[Upstream repository](https://github.com/awslabs/aws-c-sdkutils/releases/tag/v0.1.6)
dependency for aws-sdk-cpp 1.10.55 -> arrow-cpp 14.0.1 -> pyarrow 14.0.1 which would address CVE

