### PR TITLE
aws-c-sdkutils 0.2.3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,7 @@ requirements:
     - {{ compiler('c') }}
     - ninja-base
   host:
-    - aws-c-common 0.8.5
+    - aws-c-common 0.11.1
 
 test:
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,7 @@ requirements:
     - {{ compiler('c') }}
     - ninja-base
   host:
-    - aws-c-common
+    - aws-c-common 0.8.5
 
 test:
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "aws-c-sdkutils" %}
-{% set version = "0.1.6" %}
+{% set version = "0.2.3" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/awslabs/{{ name }}/archive/v{{ version }}.tar.gz
-  sha256: 8a2951344b2fb541eab1e9ca17c18a7fcbfd2aaff4cdd31d362d1fad96111b91
+  sha256: 5a0489d508341b84eea556e351717bc33524d3dfd6207ee3aba6068994ea6018
 
 build:
   number: 0
@@ -20,7 +20,7 @@ requirements:
     - {{ compiler('c') }}
     - ninja-base
   host:
-    - aws-c-common 0.8.5
+    - aws-c-common
 
 test:
   commands:
@@ -36,7 +36,7 @@ about:
   license_file: LICENSE
   summary: This is a module for the AWS SDK for C.
   description: |
-    C99 library implementing AWS SDK specific utilities. 
+    C99 library implementing AWS SDK specific utilities.
     Includes utilities for ARN parsing, reading AWS profiles, etc...
   doc_url: https://github.com/awslabs/aws-c-sdkutils
   dev_url: https://github.com/awslabs/aws-c-sdkutils


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-7287](https://anaconda.atlassian.net/browse/PKG-7287)
- [Upstream repository](https://github.com/awslabs/aws-c-sdkutils/tree/v0.2.3)

### Explanation of changes:

- Update version
- Update `aws-c-common` pinning


[PKG-7287]: https://anaconda.atlassian.net/browse/PKG-7287?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ