### PR TITLE
Rebuild against aws-c-common 0.12.6

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 493cbed4fa57e0d4622fcff044e11305eb4fc12445f32c8861025597939175fc
 
 build:
-  number: 1
+  number: 2
   run_exports:
     - {{ pin_subpackage("aws-c-sdkutils", max_pin="x.x.x") }}
 
@@ -21,7 +21,7 @@ requirements:
     - cmake >=3.9
     - ninja-base
   host:
-    - aws-c-common 0.12.4
+    - aws-c-common 0.12.6
 
 test:
   commands:


### PR DESCRIPTION
aws-c-sdkutils 0.2.4

**Destination channel:** defaults

### Links

- [PKG-11746](https://anaconda.atlassian.net/browse/PKG-11746) 
- [Upstream repository](https://github.com/awslabs/aws-c-sdkutils/tree/v0.2.4)

### Explanation of changes:
- Rebuild against aws-c-common 0.12.6


[PKG-11746]: https://anaconda.atlassian.net/browse/PKG-11746?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ