### PR TITLE
aws-c-sdkutils 0.2.4 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,7 +2,7 @@
 {% set version = "0.2.4" %}
 
 package:
-  name: {{ name|lower }}
+  name: {{ name }}
   version: {{ version }}
 
 source:
@@ -10,7 +10,7 @@ source:
   sha256: 493cbed4fa57e0d4622fcff044e11305eb4fc12445f32c8861025597939175fc
 
 build:
-  number: 2
+  number: 3
   run_exports:
     - {{ pin_subpackage("aws-c-sdkutils", max_pin="x.x.x") }}
 
@@ -21,7 +21,7 @@ requirements:
     - cmake >=3.9
     - ninja-base
   host:
-    - aws-c-common 0.12.6
+    - aws-c-common 0.14.0
 
 test:
   commands:


### PR DESCRIPTION
aws-c-sdkutils 0.2.4 

**Destination channel:** Defaults

### Links

- [PKG-15479]
- dev_url:        https://github.com/awslabs/aws-c-sdkutils/tree/v0.2.4
- conda_forge:    https://github.com/conda-forge/aws-c-sdkutils-feedstock
- pypi:           None
- pypi inspector: None

### Explanation of changes:

- new **aws-c-common** version number


[PKG-15479]: https://anaconda.atlassian.net/browse/PKG-15479?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ